### PR TITLE
Fixed directory permissions.

### DIFF
--- a/counter/cover.go
+++ b/counter/cover.go
@@ -507,6 +507,6 @@ func createDir(dirName string) {
 	_, err := os.Stat(dirName)
 	if os.IsNotExist(err) {
 		createDir(path.Dir(dirName))
-		os.Mkdir(dirName, 666)
+		os.Mkdir(dirName, 0777)
 	}
 }

--- a/database/local_db.go
+++ b/database/local_db.go
@@ -31,10 +31,11 @@ const (
 
 // Permission Permission of local database
 var Permission os.FileMode = 0666
+var DirPermission os.FileMode = 0777
 
 // NewLDB new local db
 func NewLDB(name string, cacheCap int) *LDB {
-	os.Mkdir(gDbRoot, Permission)
+	os.Mkdir(gDbRoot, DirPermission)
 	out := LDB{}
 	out.cacheTB = make(map[string]bool)
 	out.memoryTB = make(map[string]*LRUCache)

--- a/runtime/common.go
+++ b/runtime/common.go
@@ -7,7 +7,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"github.com/govm-net/govm/wallet"
 	"io/ioutil"
 	"log"
 	"os"
@@ -15,6 +14,8 @@ import (
 	"reflect"
 	"strings"
 	"sync"
+
+	"github.com/govm-net/govm/wallet"
 )
 
 // EventFilter event filter, show or drop app event
@@ -139,7 +140,7 @@ func createDir(dirName string) {
 	_, err := os.Stat(dirName)
 	if os.IsNotExist(err) {
 		createDir(path.Dir(dirName))
-		os.Mkdir(dirName, 666)
+		os.Mkdir(dirName, 0777)
 	}
 }
 


### PR DESCRIPTION
In some cases permissions were set to `666` and not `0666`. Furthermore, `0666` on directories means inaccessible (impossible to cd into) - https://unix.stackexchange.com/a/21252, so I changed it to `0777`.